### PR TITLE
Fixes #1

### DIFF
--- a/lib/h5psd.js
+++ b/lib/h5psd.js
@@ -112,7 +112,7 @@ function build(filename, argv) {
         var md5 = crypto.createHash('md5');
         md5.update(buffer);
         var flag = md5.digest('hex');
-        image = path.join(images, flag.slice(1, 7) + '.png');
+        image = images + '/' + flag.slice(1, 7) + '.png';
         if (!md5dict[flag]) { // 内容没有出现过
           md5dict[flag] = true;
           if (!nodeInfo.text) { // 非文本节点


### PR DESCRIPTION
使用了兼容系统的路径拼接会产生不同路径分隔符(正斜杠和反斜杠)的 URL, 在 Window 系统中会出现反斜杠会造成背景图片无法加载
